### PR TITLE
Bugfix hud.lua

### DIFF
--- a/res/scripts/hud.lua
+++ b/res/scripts/hud.lua
@@ -96,7 +96,7 @@ local function update_hand()
     
     local rotation = cam:get_rot()
 
-    local angle = player.get_rot() - 90
+    local angle = player.get_rot(pid) - 90
     local cos = math.cos(angle / (180 / math.pi))
     local sin = math.sin(angle / (180 / math.pi))
 


### PR DESCRIPTION
Пофикшена ошибка:
```lua
[E] 2025/08/03 14:09:45.705+0300  [           lua-debug] error in event (core:.hudrender) handler: [string "core:scripts/hud.lua"]:99: attempt to perform arithmetic on a nil value
stack traceback:
[string "core:scripts/hud.lua"]:99: in function 'update_hand'
[string "core:scripts/hud.lua"]:123: in function <[string "core:scripts/hud.lua"]:119>
[C]: in function 'xpcall'
[string "core:scripts/stdlib.lua"]:217: in function <[string "core:scripts/stdlib.lua"]:210>
```