### PR TITLE
Replace if-else chain with ArgC vector

### DIFF
--- a/src/util/command_line.cpp
+++ b/src/util/command_line.cpp
@@ -1,6 +1,9 @@
 #include "command_line.hpp"
 
 #include <iostream>
+#include <functional>
+#include <vector>
+#include <string>
 
 #include "io/engine_paths.hpp"
 #include "util/ArgsReader.hpp"
@@ -8,45 +11,66 @@
 
 namespace fs = std::filesystem;
 
+class ArgC {
+    public:
+        std::string keyword;
+        std::function<bool()> execute;
+        std::string help;
+        ArgC(const std::string& keywo, std::function<bool()> execu, const std::string& he):
+            keyword(keywo), execute(execu), help(he) {}
+};
+
+
 static bool perform_keyword(
     util::ArgsReader& reader, const std::string& keyword, CoreParameters& params
 ) {
-    if (keyword == "--res") {
-        params.resFolder = reader.next();
-    } else if (keyword == "--dir") {
-        params.userFolder = reader.next();
-    } else if (keyword == "--project") {
-        params.projectFolder = reader.next();
-    } else if (keyword == "--help" || keyword == "-h") {
-        std::cout << "VoxelCore v" << ENGINE_VERSION_STRING << "\n\n";
-        std::cout << "command-line arguments:\n";
-        std::cout << " --help - display this help\n";
-        std::cout << " --version - display engine version\n";
-        std::cout << " --res <path> - set resources directory\n";
-        std::cout << " --dir <path> - set userfiles directory\n";
-        std::cout << " --project <path> - set project directory\n";
-        std::cout << " --headless - run in headless mode\n";
-        std::cout << " --test <path> - test script file\n";
-        std::cout << " --script <path> - main script file\n";
-        std::cout << std::endl;
-        return false;
-    } else if (keyword == "--version") {
-        std::cout << ENGINE_VERSION_STRING << std::endl;
-        return false;
-    } else if (keyword == "--headless") {
-        params.headless = true;
-    } else if (keyword == "--test") {
-        auto token = reader.next();
-        params.testMode = true;
-        params.scriptFile = token;
-    } else if (keyword == "--script") {
-        auto token = reader.next();
-        params.testMode = false;
-        params.scriptFile = token;
-    } else {
-        throw std::runtime_error("unknown argument " + keyword);
+    const std::vector<ArgC> argumentsCommandline = {
+        ArgC("--res", [&params, &reader]() -> bool {
+            params.resFolder = reader.next();
+            return true;
+        }, "<path> - set resources directory."),
+        ArgC("--dir", [&params, &reader]() -> bool {
+            params.userFolder = reader.next();
+            return true;
+        }, "<path> - set userfiles directory."),
+        ArgC("--project", [&params, &reader]() -> bool {
+            params.projectFolder = reader.next();
+            return true;
+        }, "<path> - set project directory."),
+        ArgC("--test", [&params, &reader]() -> bool {
+            params.testMode = true;
+            params.scriptFile = reader.next();
+            return true;
+        }, "<path> - test script file."),
+        ArgC("--script", [&params, &reader]() -> bool {
+            params.testMode = false;
+            params.scriptFile = reader.next();
+            return true;
+        }, "<path> - main script file."),
+        ArgC("--headless", [&params]() -> bool {
+            params.headless = true;
+            return true;
+        }, "- run in headless mode."),
+        ArgC("--version", []() -> bool {
+            std::cout << ENGINE_VERSION_STRING << std::endl;
+            return false;
+        }, "- display the engine version."),
+        ArgC("--help", [&argumentsCommandline]() -> bool {
+            std::cout << "VoxelCore v" << ENGINE_VERSION_STRING << "\n\n";
+            std::cout << "Command-line arguments:\n";
+            for (auto a : argumentsCommandline) {
+                std::cout << a.keyword << " " << a.help << std::endl;
+            }
+            std::cout << std::endl;
+            return false;
+        }, "- display this help.")
+    };
+    for (auto a : argumentsCommandline) {
+        if (a.keyword == keyword) {
+            return a.execute();
+        }
     }
-    return true;
+    throw std::runtime_error("unknown argument " + keyword);
 }
 
 bool parse_cmdline(int argc, char** argv, CoreParameters& params) {

--- a/src/util/command_line.cpp
+++ b/src/util/command_line.cpp
@@ -16,8 +16,11 @@ class ArgC {
         std::string keyword;
         std::function<bool()> execute;
         std::string help;
-        ArgC(const std::string& keywo, std::function<bool()> execu, const std::string& he):
-            keyword(keywo), execute(execu), help(he) {}
+        ArgC(const std::string& keyword, std::function<bool()> execute, const std::string& help) {
+            this->keyword = keyword;
+            this->execute = execute;
+            this->help = help;
+        }
 };
 
 

--- a/src/util/command_line.cpp
+++ b/src/util/command_line.cpp
@@ -24,7 +24,7 @@ class ArgC {
 static bool perform_keyword(
     util::ArgsReader& reader, const std::string& keyword, CoreParameters& params
 ) {
-    const std::vector<ArgC> argumentsCommandline = {
+    static const std::vector<ArgC> argumentsCommandline = {
         ArgC("--res", [&params, &reader]() -> bool {
             params.resFolder = reader.next();
             return true;
@@ -55,17 +55,17 @@ static bool perform_keyword(
             std::cout << ENGINE_VERSION_STRING << std::endl;
             return false;
         }, "- display the engine version."),
-        ArgC("--help", [&argumentsCommandline]() -> bool {
+        ArgC("--help", []() -> bool {
             std::cout << "VoxelCore v" << ENGINE_VERSION_STRING << "\n\n";
             std::cout << "Command-line arguments:\n";
-            for (auto a : argumentsCommandline) {
+            for (auto& a : argumentsCommandline) {
                 std::cout << a.keyword << " " << a.help << std::endl;
             }
             std::cout << std::endl;
             return false;
         }, "- display this help.")
     };
-    for (auto a : argumentsCommandline) {
+    for (auto& a : argumentsCommandline) {
         if (a.keyword == keyword) {
             return a.execute();
         }


### PR DESCRIPTION
Introduce argc class to represent individual arguments (keyword, execute function, help text)
Replace if-else chain with argc vector and iterate to execute matching argument
Automatically generate help text from argument table, eliminating duplication
Simplifies adding new arguments - only add a new element, help function updates automatically
Improves readability and maintainability, especially for expanding cli options