### PR TITLE
Fix file.gzip_compress/decompress

### DIFF
--- a/doc/ru/scripting/builtins/libfile.md
+++ b/doc/ru/scripting/builtins/libfile.md
@@ -44,6 +44,18 @@ file.write_bytes(путь: str, data: array of integers)
 Записывает массив байт в файл (с перезаписью)
 
 ```python
+file.gzip_compress(data: array of integers, [опционально] usetable) -> array of integers
+```
+
+Сжимает массив байт алгоритмом gzip. При значении usetable = false возвращает Bytearray вместо table.
+
+```python
+file.gzip_decompress(data: array of integers, [опционально] usetable) -> array of integers
+```
+
+Разжимает массив байт, который был сжат алгоритмом gzip. При значении usetable = false возвращает Bytearray вместо table.
+
+```python
 file.length(путь: str) -> int
 ```
 

--- a/src/logic/scripting/lua/libs/libfile.cpp
+++ b/src/logic/scripting/lua/libs/libfile.cpp
@@ -189,30 +189,26 @@ static int l_list(lua::State* L) {
 }
 
 static int l_gzip_compress(lua::State* L) {
-    std::vector<ubyte> bytes;
+    auto string = lua::bytearray_as_string(L, 1);
 
-    lua::read_bytes_from_table(L, 1, bytes);
-    auto compressed_bytes = gzip::compress(bytes.data(), bytes.size());
-    int newTable = lua::gettop(L);
+    auto compressedBytes = gzip::compress(
+        reinterpret_cast<const ubyte*>(string.data()),
+        string.size()
+    );
 
-    for (size_t i = 0; i < compressed_bytes.size(); i++) {
-        lua::pushinteger(L, compressed_bytes.data()[i]);
-        lua::rawseti(L, i + 1, newTable);
-    }
+    lua::create_bytearray(L, std::move(compressedBytes));
     return 1;
 }
 
 static int l_gzip_decompress(lua::State* L) {
-    std::vector<ubyte> bytes;
+    auto string = lua::bytearray_as_string(L, 1);
 
-    lua::read_bytes_from_table(L, 1, bytes);
-    auto decompressed_bytes = gzip::decompress(bytes.data(), bytes.size());
-    int newTable = lua::gettop(L);
+    auto decompressedBytes = gzip::decompress(
+        reinterpret_cast<const ubyte*>(string.data()),
+        string.size()
+    );
 
-    for (size_t i = 0; i < decompressed_bytes.size(); i++) {
-        lua::pushinteger(L, decompressed_bytes.data()[i]);
-        lua::rawseti(L, i + 1, newTable);
-    }
+    lua::create_bytearray(L, std::move(decompressedBytes));
     return 1;
 }
 

--- a/src/logic/scripting/lua/libs/libfile.cpp
+++ b/src/logic/scripting/lua/libs/libfile.cpp
@@ -189,26 +189,48 @@ static int l_list(lua::State* L) {
 }
 
 static int l_gzip_compress(lua::State* L) {
-    auto string = lua::bytearray_as_string(L, 1);
-
+    char argc = lua_gettop(L);
+    auto str = lua::bytearray_as_string(L, 1);
     auto compressedBytes = gzip::compress(
-        reinterpret_cast<const ubyte*>(string.data()),
-        string.size()
+        reinterpret_cast<const ubyte*>(str.data()),
+        str.size()
     );
 
-    lua::create_bytearray(L, std::move(compressedBytes));
+    if (argc < 2 || !lua::toboolean(L, 2)) {
+        lua::create_bytearray(L, std::move(compressedBytes));
+    } else {
+        size_t length = compressedBytes.size();
+        lua::createtable(L, length, 0);
+        int newTable = lua::gettop(L);
+        for (size_t i = 0; i < length; i++) {
+            lua::pushinteger(L, compressedBytes.data()[i]);
+            lua::rawseti(L, i + 1, newTable);
+        }
+    }
+
     return 1;
 }
 
 static int l_gzip_decompress(lua::State* L) {
-    auto string = lua::bytearray_as_string(L, 1);
-
+    char argc = lua_gettop(L);
+    auto str = lua::bytearray_as_string(L, 1);
     auto decompressedBytes = gzip::decompress(
-        reinterpret_cast<const ubyte*>(string.data()),
-        string.size()
+        reinterpret_cast<const ubyte*>(str.data()),
+        str.size()
     );
 
-    lua::create_bytearray(L, std::move(decompressedBytes));
+    if (argc < 2 || !lua::toboolean(L, 2)) {
+        lua::create_bytearray(L, std::move(decompressedBytes));
+    } else {
+        size_t length = decompressedBytes.size();
+        lua::createtable(L, length, 0);
+        int newTable = lua::gettop(L);
+        for (size_t i = 0; i < length; i++) {
+            lua::pushinteger(L, decompressedBytes.data()[i]);
+            lua::rawseti(L, i + 1, newTable);
+        }
+    }
+
     return 1;
 }
 


### PR DESCRIPTION
Старые функции, которые пора задокументировать и перевести на Bytearray

```python
file.gzip_compress(data: array of integers, [опционально] usetable) -> array of integers
```

Сжимает массив байт алгоритмом gzip. При значении usetable = false возвращает Bytearray вместо table.

```python
file.gzip_decompress(data: array of integers, [опционально] usetable) -> array of integers
```