### PR TITLE
Blocks renderer and generator update review

### DIFF
--- a/src/graphics/render/ChunksRenderer.cpp
+++ b/src/graphics/render/ChunksRenderer.cpp
@@ -396,11 +396,6 @@ void ChunksRenderer::drawSortedMeshes(const Camera& camera, Shader& shader) {
         order.push_back(VisibleChunkTrans{glm::ivec2(chunk->x, chunk->z), &chunks[index.index], nearest});
     }
 
-    // Sort chunks by nearest translucent distance back-to-front (far to near)
-    std::sort(order.begin(), order.end(), [](const VisibleChunkTrans& a, const VisibleChunkTrans& b) {
-        return a.nearestDist2 > b.nearestDist2;
-    });
-
     // Draw per-chunk sorted mesh (keeps GPU buffers and avoids per-frame repack)
     for (const auto& item : order) {
         const auto& chunk = *item.chunkPtr;

--- a/src/graphics/render/ChunksRenderer.cpp
+++ b/src/graphics/render/ChunksRenderer.cpp
@@ -363,12 +363,11 @@ void ChunksRenderer::drawSortedMeshes(const Camera& camera, Shader& shader) {
     struct VisibleChunkTrans {
         glm::ivec2 key;
         const std::shared_ptr<Chunk>* chunkPtr;
-        long long nearestDist2;
     };
     std::vector<VisibleChunkTrans> order;
     order.reserve(indices.size());
 
-    // Build per-chunk nearest distance for translucent entries
+    // Build list of visible translucent chunks in the same order as indices
     for (const auto& index : indices) {
         const auto& chunk = chunks[index.index];
         if (chunk == nullptr || !chunk->flags.lighted) {
@@ -388,12 +387,10 @@ void ChunksRenderer::drawSortedMeshes(const Camera& camera, Shader& shader) {
             if (!frustum.isBoxVisible(bounds.min, bounds.max)) continue;
         }
 
-        long long nearest = LLONG_MAX;
-        for (const auto& e : entries) {
-            long long d2 = static_cast<long long>(glm::distance2(e.position, cameraPos));
-            if (d2 < nearest) nearest = d2;
-        }
-        order.push_back(VisibleChunkTrans{glm::ivec2(chunk->x, chunk->z), &chunks[index.index], nearest});
+        order.push_back(VisibleChunkTrans{
+            glm::ivec2(chunk->x, chunk->z),
+            &chunks[index.index]
+        });
     }
 
     // Draw per-chunk sorted mesh (keeps GPU buffers and avoids per-frame repack)


### PR DESCRIPTION
1. Убрал лишнюю сортировку order по nearestDist2 — она не влияла на порядок отрисовки, т.к. используется порядок из indices
2. Убрал вычисление nearestDist2 (цикл по entries с glm::distance2) и поле nearestDist2 из структуры VisibleChunkTrans — они больше не используются после удаления сортировки