### PR TITLE
Fix typos in docs

### DIFF
--- a/dev/tests/network_http.lua
+++ b/dev/tests/network_http.lua
@@ -4,7 +4,7 @@ network.get("https://api.github.com/repos/MihailRis/VoxelEngine-Cpp/releases/lat
     print(json.parse(s).name)
     response_received = true
 end, function (code)
-    print("repond with code", code)
+    print("respond with code", code)
     response_received = true
 end)
 

--- a/doc/en/block-models.md
+++ b/doc/en/block-models.md
@@ -1,4 +1,4 @@
-# Block Models (depricated)
+# Block Models (deprecated)
 
 > ![WARNING]
 > The `model-primitives` property is deprecated. Use the [VCM format](vcm.md) for a textual description of the model's primitives.

--- a/doc/en/scripting/builtins/libblock.md
+++ b/doc/en/scripting/builtins/libblock.md
@@ -151,7 +151,7 @@ block.raycast(start: vec3, dir: vec3, max_distance: number, [optional] dest: tab
 Casts a ray from the start point in the direction of *dir*. Max_distance specifies the maximum ray length.
 
 Argument `filter` can be used to tell ray what blocks can be skipped(passed through) during ray-casting.
-To use filter `dest` argument must be filled with some value(can be nil), it's done for backwards compatability 
+To use filter `dest` argument must be filled with some value(can be nil), it's done for backwards compatibility 
 
 The `include_non_selectable` argument determines whether blocks that cannot be selected by the cursor will be included.
 Example - `base:water`

--- a/doc/en/scripting/builtins/libinventory.md
+++ b/doc/en/scripting/builtins/libinventory.md
@@ -186,7 +186,7 @@ inventory.clone(invid: int) -> int
 
 -- Move an item from slotA of invA to slotB of invB. 
 -- invA may be the same as invB.
--- If slotB will be chosen automaticly if argument is not specified.
+-- If slotB will be chosen automatically if argument is not specified.
 -- The move may be incomplete if the available slot has no enough stack space.
 inventory.move(invA: int, slotA: int, invB: int, slotB: int)
 

--- a/doc/en/scripting/builtins/libplayer.md
+++ b/doc/en/scripting/builtins/libplayer.md
@@ -154,7 +154,7 @@ Returns position of the selected block or nil
 player.get_selected_entity(playerid: int) -> int
 ```
 
-Returns unique indentifier of the entity selected by player
+Returns unique identifier of the entity selected by player
 
 ```lua
 player.get_entity(playerid: int) -> int

--- a/doc/en/scripting/ecs.md
+++ b/doc/en/scripting/ecs.md
@@ -8,7 +8,7 @@ The entity object is available in components as a global variable **entity**.
 -- Deletes an entity (the entity may continue to exist until the frame ends, but will not be displayed in that frame)
 entity:despawn()
 
--- Returns entity defintion index (integer ID)
+-- Returns entity definition index (integer ID)
 entity:def_index() -> int
 
 -- Returns entity definition name (string ID)

--- a/doc/specs/debugging_protocol.md
+++ b/doc/specs/debugging_protocol.md
@@ -79,7 +79,7 @@ Configuring connection. Disconnect-action is action that debugged instance must 
 
 - `frame` - Call stack frame index (indexing from most recent call)
 - `local` - Local variable index (based on `paused` event stack trace)
-- `path` - Requsted value path segments. Example: `['a', 'b', 5]` is `local_variable.a.b[5]`
+- `path` - Requested value path segments. Example: `['a', 'b', 5]` is `local_variable.a.b[5]`
 
 Responds with:
 

--- a/doc/specs/vec3_model_spec.md
+++ b/doc/specs/vec3_model_spec.md
@@ -16,7 +16,7 @@ enum AttributeType:uint8 {
 sizeof(AttributeType) == 1;
 
 struct VertexAttribute {
-    AttributeType type; // data type is infered from attribute type
+    AttributeType type; // data type is inferred from attribute type
     uint8 flags;
     uint32 size;
     float data[]; // if compressed, first 4 bytes of compressed data is decompressed size


### PR DESCRIPTION
Typos found with codespell, in the docs and one test:
- `doc/specs/debugging_protocol.md`: "Requsted" -> "Requested"
- `doc/specs/vec3_model_spec.md`: "infered" -> "inferred"
- `doc/en/block-models.md`: "depricated" -> "deprecated"
- `doc/en/scripting/ecs.md`: "defintion" -> "definition"
- `doc/en/scripting/builtins/libblock.md`: "compatability" -> "compatibility"
- `doc/en/scripting/builtins/libinventory.md`: "automaticly" -> "automatically"
- `doc/en/scripting/builtins/libplayer.md`: "indentifier" -> "identifier"
- `dev/tests/network_http.lua`: "repond with code" -> "respond with code"
