### PR TITLE
Fix typos in comments and log messages

### DIFF
--- a/src/audio/audio.hpp
+++ b/src/audio/audio.hpp
@@ -413,7 +413,7 @@ namespace audio {
     /// @brief Load audio file info and PCM data
     /// @param file audio file
     /// @param headerOnly read header only
-    /// @throws std::runtime_error if I/O error ocurred or format is unknown
+    /// @throws std::runtime_error if I/O error occurred or format is unknown
     /// @return PCM audio data
     std::unique_ptr<PCM> load_PCM(const io::path& file, bool headerOnly);
 
@@ -421,7 +421,7 @@ namespace audio {
     /// @param file audio file path
     /// @param keepPCM store PCM data in sound to make it accessible with
     /// Sound::getPCM
-    /// @throws std::runtime_error if I/O error ocurred or format is unknown
+    /// @throws std::runtime_error if I/O error occurred or format is unknown
     /// @return new Sound instance
     std::unique_ptr<Sound> load_sound(const io::path& file, bool keepPCM);
 
@@ -434,7 +434,7 @@ namespace audio {
 
     /// @brief Open new PCM stream from file
     /// @param file audio file path
-    /// @throws std::runtime_error if I/O error ocurred or format is unknown
+    /// @throws std::runtime_error if I/O error occurred or format is unknown
     /// @return new PCMStream instance
     std::unique_ptr<PCMStream> open_PCM_stream(const io::path& file);
 

--- a/src/coders/wav.cpp
+++ b/src/coders/wav.cpp
@@ -69,7 +69,7 @@ public:
             return 0;
         }
         if (in.fail()) {
-            logger.error() << "Wav::load_pcm: I/O error ocurred";
+            logger.error() << "Wav::load_pcm: I/O error occurred";
             return -1;
         }
         return in.gcount();

--- a/src/frontend/hud.hpp
+++ b/src/frontend/hud.hpp
@@ -119,7 +119,7 @@ class Hud : public util::ObjectsKeeper {
     /// @brief Allow actual pause
     bool allowPause = true;
     bool debug = false;
-    /// @brief UI element will be dynamicly positioned near to inventory or in screen center
+    /// @brief UI element will be dynamically positioned near to inventory or in screen center
     std::shared_ptr<gui::UINode> secondUI;
 
     std::shared_ptr<gui::UINode> debugMinimap;

--- a/src/logic/scripting/lua/lua_util.hpp
+++ b/src/logic/scripting/lua/lua_util.hpp
@@ -323,7 +323,7 @@ namespace lua {
 
         if (found == usertypeNames.end()) {
             log_error(
-                "usertype is not registred: " + std::string(typeid(T).name())
+                "usertype is not registered: " + std::string(typeid(T).name())
             );
         } else if (getglobal(L, found->second)) {
             setmetatable(L);

--- a/src/network/Sockets.cpp
+++ b/src/network/Sockets.cpp
@@ -161,7 +161,7 @@ public:
                 state = ConnectionState::CLOSED;
                 break;
             } else if (size < 0) {
-                logger.warning() << "an error ocurred while receiving from "
+                logger.warning() << "an error occurred while receiving from "
                             << to_string(addr);
                 auto error = handle_socket_error("recv(...) error");
                 closesocket(descriptor);

--- a/src/presets/ParticlesPreset.hpp
+++ b/src/presets/ParticlesPreset.hpp
@@ -8,10 +8,10 @@
 #include "util/EnumMetadata.hpp"
 
 enum class ParticleSpawnShape {
-    /// @brief Coordinates are regulary distributed within 
+    /// @brief Coordinates are regularly distributed within 
     /// the volume of a ball.
     BALL = 0,
-    /// @brief Coordinates are regulary distributed on 
+    /// @brief Coordinates are regularly distributed on 
     /// a sphere.
     SPHERE,
     /// @brief Coordinates are uniform distributed within 

--- a/src/util/SmallHeap.hpp
+++ b/src/util/SmallHeap.hpp
@@ -19,7 +19,7 @@ namespace util {
 
     /// @brief Simple heap implementation for memory-optimal sparse array of 
     /// small different structures
-    /// @note alignment is not impemented 
+    /// @note alignment is not implemented 
     /// (impractical in the context of scripting and memory consumption)
     /// @tparam Tindex entry index type
     /// @tparam Tsize entry size type

--- a/src/world/files/WorldRegions.cpp
+++ b/src/world/files/WorldRegions.cpp
@@ -323,7 +323,7 @@ void WorldRegions::processBlocksData(int x, int z, const BlockDataProc& func) {
             try {
                 func(&blocksData, std::move(voxData));
             } catch (const std::exception& err) {
-                logger.error() << "an error ocurred while processing blocks "
+                logger.error() << "an error occurred while processing blocks "
                     "data in chunk (" << gx << ", " << gz << "): " << err.what();
                 blocksData = {};
             }


### PR DESCRIPTION
Typos in comments, doxygen notes and log strings (no functional changes):
- "ocurred" -> "occurred" in `wav.cpp`, `Sockets.cpp`, `WorldRegions.cpp`, and `audio.hpp` (3x)
- `src/frontend/hud.hpp`: "dynamicly" -> "dynamically"
- `src/util/SmallHeap.hpp`: "impemented" -> "implemented"
- `src/presets/ParticlesPreset.hpp`: "regulary" -> "regularly" (2x)
- `src/logic/scripting/lua/lua_util.hpp`: exception message "usertype is not registred" -> "not registered" (no other references to the old text)
