### PR TITLE
fix: correct emission copy and cleanup Block code

### DIFF
--- a/src/content/ContentBuilder.cpp
+++ b/src/content/ContentBuilder.cpp
@@ -33,11 +33,11 @@ std::unique_ptr<Content> ContentBuilder::build() {
 
         if (def.variants) {
             for (auto& variant : def.variants->variants) {
-                variant.rt.solid = isSolid(variant) || def.explictlySolid;
+                variant.rt.solid = isSolid(variant) || def.explicitlySolid;
             }
             def.defaults = def.variants->variants.at(0);
         } else {
-            def.defaults.rt.solid = isSolid(def.defaults) || def.explictlySolid;
+            def.defaults.rt.solid = isSolid(def.defaults) || def.explicitlySolid;
         }
         def.rt.solid = def.defaults.rt.solid;
 

--- a/src/content/loading/BlockLoader.cpp
+++ b/src/content/loading/BlockLoader.cpp
@@ -255,7 +255,7 @@ template<> void ContentUnitLoader<Block>::loadUnit(
     root.at("tick-interval").get(def.tickInterval);
     root.at("overlay-texture").get(def.overlayTexture);
     root.at("translucent").get(def.translucent);
-    root.at("solid").get(def.explictlySolid);
+    root.at("solid").get(def.explicitlySolid);
 
     if (root.has("fields")) {
         def.dataStruct = std::make_unique<StructLayout>();

--- a/src/voxels/Block.cpp
+++ b/src/voxels/Block.cpp
@@ -129,13 +129,6 @@ Block::Block(const std::string& name)
 
 Block::~Block() = default;
 
-Block::Block(std::string name, const std::string& texture)
-    : name(std::move(name)) {
-    for (int i = 0; i < defaults.textureFaces.size(); i++) {
-        defaults.textureFaces[i] = TEXTURE_NOTFOUND;
-    }
-}
-
 void Block::cloneTo(Block& dst) {
     dst.caption = caption;
     dst.defaults = defaults;
@@ -143,7 +136,7 @@ void Block::cloneTo(Block& dst) {
         dst.variants = std::make_unique<Variants>(*variants);
     }
     dst.material = material;
-    std::copy(&emission[0], &emission[3], dst.emission);
+    std::copy(&emission[0], &emission[4], dst.emission);
     dst.size = size;
     dst.lightPassing = lightPassing;
     dst.skyLightPassing = skyLightPassing;
@@ -165,7 +158,7 @@ void Block::cloneTo(Block& dst) {
     dst.tickInterval = tickInterval;
     dst.overlayTexture = overlayTexture;
     dst.translucent = translucent;
-    dst.explictlySolid = explictlySolid;
+    dst.explicitlySolid = explicitlySolid;
     dst.tags = tags;
     if (dataStruct) {
         dst.dataStruct = std::make_unique<data::StructLayout>(*dataStruct);
@@ -173,11 +166,4 @@ void Block::cloneTo(Block& dst) {
     if (particles) {
         dst.particles = std::make_unique<ParticlesPreset>(*particles);
     }
-}
-
-static std::set<std::string, std::less<>> RESERVED_BLOCK_FIELDS {
-};
-
-bool Block::isReservedBlockField(std::string_view view) {
-    return RESERVED_BLOCK_FIELDS.find(view) != RESERVED_BLOCK_FIELDS.end();
 }

--- a/src/voxels/Block.hpp
+++ b/src/voxels/Block.hpp
@@ -255,7 +255,7 @@ public:
     bool translucent = false;
 
     /// @brief Explicitly overriding 'solid' property if true assigned
-    bool explictlySolid = false;
+    bool explicitlySolid = false;
 
     /// @brief Grounding behaviour
     GroundingBehaviour groundingBehaviour = GroundingBehaviour::PARTIAL;
@@ -328,7 +328,6 @@ public:
     } rt {};
 
     Block(const std::string& name);
-    Block(std::string name, const std::string& texture);
     Block(const Block&) = delete;
     ~Block();
 
@@ -349,16 +348,15 @@ public:
     }
 
     const Variant& getVariant(uint8_t index) const {
-        if (index == 0)
+        if (index == 0 || variants == nullptr)
             return defaults;
+        assert(index < variants->variants.size());
         return variants->variants[index];
     }
 
     const BlockModel& getModel(uint8_t bits) const {
         return getVariantByBits(bits).model;
     }
-
-    static bool isReservedBlockField(std::string_view view);
 };
 
 inline glm::ivec3 get_ground_direction(const Block& def, int rotation) {


### PR DESCRIPTION
Possible bug fix:
Block::cloneTo: std::copy(&emission[0], &emission[3], ...) copies only
3 of 4 emission elements (range is [first, last)). The field is
documented as "R, G, B, S", so the 4th (sky-light) component appears
to be unintentionally skipped. Fixed to &emission[4].

Cleanup:
Removed unused constructor Block(std::string, const std::string&).
Removed unused RESERVED_BLOCK_FIELDS and Block::isReservedBlockField.
Renamed explictlySolid to explicitlySolid (typo) in Block, ContentBuilder, and BlockLoader.
Added assert and null-check in Block::getVariant.

How it was tested
Debug build with MSVC (VS 2026) — compiles without errors.
ctest -C Debug — 45/45 tests passed.
Manual run: game launches, world loads, blocks place/break correctly.